### PR TITLE
WPF can not receive the touch message when set the WS_EX_TRANSPARENT

### DIFF
--- a/CanNotReceiveTouchMessageWS_EX_TRANSPARENT/App.xaml
+++ b/CanNotReceiveTouchMessageWS_EX_TRANSPARENT/App.xaml
@@ -1,0 +1,9 @@
+﻿<Application x:Class="CanNotReceiveTouchMessageWS_EX_TRANSPARENT.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:CanNotReceiveTouchMessageWS_EX_TRANSPARENT"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+         
+    </Application.Resources>
+</Application>

--- a/CanNotReceiveTouchMessageWS_EX_TRANSPARENT/App.xaml.cs
+++ b/CanNotReceiveTouchMessageWS_EX_TRANSPARENT/App.xaml.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Data;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace CanNotReceiveTouchMessageWS_EX_TRANSPARENT
+{
+    /// <summary>
+    /// Interaction logic for App.xaml
+    /// </summary>
+    public partial class App : Application
+    {
+    }
+}

--- a/CanNotReceiveTouchMessageWS_EX_TRANSPARENT/AssemblyInfo.cs
+++ b/CanNotReceiveTouchMessageWS_EX_TRANSPARENT/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+using System.Windows;
+
+[assembly: ThemeInfo(
+    ResourceDictionaryLocation.None, //where theme specific resource dictionaries are located
+                                     //(used if a resource is not found in the page,
+                                     // or application resource dictionaries)
+    ResourceDictionaryLocation.SourceAssembly //where the generic resource dictionary is located
+                                              //(used if a resource is not found in the page,
+                                              // app, or any theme specific resource dictionaries)
+)]

--- a/CanNotReceiveTouchMessageWS_EX_TRANSPARENT/CanNotReceiveTouchMessageWS_EX_TRANSPARENT.csproj
+++ b/CanNotReceiveTouchMessageWS_EX_TRANSPARENT/CanNotReceiveTouchMessageWS_EX_TRANSPARENT.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+
+</Project>

--- a/CanNotReceiveTouchMessageWS_EX_TRANSPARENT/CanNotReceiveTouchMessageWS_EX_TRANSPARENT.sln
+++ b/CanNotReceiveTouchMessageWS_EX_TRANSPARENT/CanNotReceiveTouchMessageWS_EX_TRANSPARENT.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CanNotReceiveTouchMessageWS_EX_TRANSPARENT", "CanNotReceiveTouchMessageWS_EX_TRANSPARENT.csproj", "{F395C415-7D56-4ED4-82B3-FCF86088D7C3}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F395C415-7D56-4ED4-82B3-FCF86088D7C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F395C415-7D56-4ED4-82B3-FCF86088D7C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F395C415-7D56-4ED4-82B3-FCF86088D7C3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F395C415-7D56-4ED4-82B3-FCF86088D7C3}.Debug|x64.Build.0 = Debug|Any CPU
+		{F395C415-7D56-4ED4-82B3-FCF86088D7C3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F395C415-7D56-4ED4-82B3-FCF86088D7C3}.Debug|x86.Build.0 = Debug|Any CPU
+		{F395C415-7D56-4ED4-82B3-FCF86088D7C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F395C415-7D56-4ED4-82B3-FCF86088D7C3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F395C415-7D56-4ED4-82B3-FCF86088D7C3}.Release|x64.ActiveCfg = Release|Any CPU
+		{F395C415-7D56-4ED4-82B3-FCF86088D7C3}.Release|x64.Build.0 = Release|Any CPU
+		{F395C415-7D56-4ED4-82B3-FCF86088D7C3}.Release|x86.ActiveCfg = Release|Any CPU
+		{F395C415-7D56-4ED4-82B3-FCF86088D7C3}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/CanNotReceiveTouchMessageWS_EX_TRANSPARENT/MainWindow.xaml
+++ b/CanNotReceiveTouchMessageWS_EX_TRANSPARENT/MainWindow.xaml
@@ -1,0 +1,12 @@
+﻿<Window x:Class="CanNotReceiveTouchMessageWS_EX_TRANSPARENT.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:CanNotReceiveTouchMessageWS_EX_TRANSPARENT"
+        mc:Ignorable="d"
+        Title="MainWindow" Height="450" Width="800">
+    <Grid>
+        <TextBlock x:Name="TextBlock" Margin="10,10,10,10" VerticalAlignment="Bottom" TextWrapping="Wrap"></TextBlock>
+    </Grid>
+</Window>

--- a/CanNotReceiveTouchMessageWS_EX_TRANSPARENT/MainWindow.xaml.cs
+++ b/CanNotReceiveTouchMessageWS_EX_TRANSPARENT/MainWindow.xaml.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Interop;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace CanNotReceiveTouchMessageWS_EX_TRANSPARENT
+{
+    /// <summary>
+    /// Interaction logic for MainWindow.xaml
+    /// </summary>
+    public partial class MainWindow : Window
+    {
+        public MainWindow()
+        {
+            InitializeComponent();
+
+            MouseDown += MainWindow_MouseDown;
+            TouchDown += MainWindow_TouchDown;
+
+            Loaded += MainWindow_Loaded;
+        }
+
+        private void MainWindow_Loaded(object sender, RoutedEventArgs e)
+        {
+            IntPtr hwnd = new WindowInteropHelper(this).Handle;
+            var extendedStyle = GetWindowLong(hwnd, GWL_EXSTYLE);
+            SetWindowLong(hwnd, GWL_EXSTYLE, extendedStyle | WS_EX_TRANSPARENT);
+        }
+
+        [DllImport("user32.dll")]
+        private static extern int SetWindowLong(IntPtr window, int index, int value);
+
+        private const int GWL_EXSTYLE = -20;
+
+        private const int WS_EX_TRANSPARENT = 0x00000020;
+
+        [DllImport("user32.dll")]
+        private static extern int GetWindowLong(IntPtr window, int index);
+
+        private void MainWindow_TouchDown(object sender, TouchEventArgs e)
+        {
+            Log("Touch down");
+        }
+
+        private void MainWindow_MouseDown(object sender, MouseButtonEventArgs e)
+        {
+            Log("Mouse down");
+        }
+
+        private void Log(string message)
+        {
+            TextBlock.Text += $"{DateTime.Now} {message} \r\n";
+        }
+    }
+}

--- a/CanNotReceiveTouchMessageWS_EX_TRANSPARENT/README.md
+++ b/CanNotReceiveTouchMessageWS_EX_TRANSPARENT/README.md
@@ -1,0 +1,16 @@
+# WPF can not receive the touch message when set WS_EX_TRANSPARENT to window
+
+We can create an empty WPF application, and then we can output message when we receive the mouse down and touch down event
+
+But when we set the WS_EX_TRANSPARENT property to the window, that we can find that we can only receive the mouse event and can not receive the touch event
+
+```csharp
+        private void MainWindow_Loaded(object sender, RoutedEventArgs e)
+        {
+            IntPtr hwnd = new WindowInteropHelper(this).Handle;
+            var extendedStyle = GetWindowLong(hwnd, GWL_EXSTYLE);
+            SetWindowLong(hwnd, GWL_EXSTYLE, extendedStyle | WS_EX_TRANSPARENT);
+        }
+```
+
+Here is the mini demo code: https://github.com/dotnet-campus/wpf-issues/tree/master/CanNotReceiveTouchMessageWS_EX_TRANSPARENT


### PR DESCRIPTION
We can create an empty WPF application, and then we can output message when we receive the mouse down and touch down event

But when we set the WS_EX_TRANSPARENT property to the window, that we can find that we can only receive the mouse event and can not receive the touch event

```csharp
        private void MainWindow_Loaded(object sender, RoutedEventArgs e)
        {
            IntPtr hwnd = new WindowInteropHelper(this).Handle;
            var extendedStyle = GetWindowLong(hwnd, GWL_EXSTYLE);
            SetWindowLong(hwnd, GWL_EXSTYLE, extendedStyle | WS_EX_TRANSPARENT);
        }
```